### PR TITLE
publish-image action

### DIFF
--- a/.github/workflows/image-push.yml
+++ b/.github/workflows/image-push.yml
@@ -28,15 +28,7 @@ jobs:
       with:
         image: "hardened-addon-resizer"
         tag: ${{ github.event.release.tag_name }}
-        platforms: linux/amd64, linux/arm64
-
-        public-registry: docker.io
         public-repo: rancher
         public-username: ${{ env.DOCKER_USERNAME }}
         public-password: ${{ env.DOCKER_PASSWORD }}
-
         push-to-prime: false
-        prime-registry: ${{ env.PRIME_REGISTRY }}
-        prime-repo: rancher
-        prime-username: ${{ env.PRIME_REGISTRY_USERNAME }}
-        prime-password: ${{ env.PRIME_REGISTRY_PASSWORD }}

--- a/.github/workflows/image-push.yml
+++ b/.github/workflows/image-push.yml
@@ -21,14 +21,22 @@ jobs:
       with:
         secrets: |
           secret/data/github/repo/${{ github.repository }}/dockerhub/${{ github.repository_owner }}/credentials username | DOCKER_USERNAME ;
-          secret/data/github/repo/${{ github.repository }}/dockerhub/${{ github.repository_owner }}/credentials password | DOCKER_PASSWORD
+          secret/data/github/repo/${{ github.repository }}/dockerhub/${{ github.repository_owner }}/credentials password | DOCKER_PASSWORD ;
+          secret/data/github/repo/${{ github.repository }}/rancher-prime-registry/credentials registry | PRIME_REGISTRY ;
+          secret/data/github/repo/${{ github.repository }}/rancher-prime-registry/credentials username | PRIME_REGISTRY_USERNAME ;
+          secret/data/github/repo/${{ github.repository }}/rancher-prime-registry/credentials password | PRIME_REGISTRY_PASSWORD
 
     - name: Build and push image
       uses: rancher/ecm-distro-tools/actions/publish-image@master
       with:
         image: "hardened-addon-resizer"
         tag: ${{ github.event.release.tag_name }}
+
         public-repo: rancher
         public-username: ${{ env.DOCKER_USERNAME }}
         public-password: ${{ env.DOCKER_PASSWORD }}
-        push-to-prime: false
+
+        prime-repo: rancher
+        prime-registry: ${{ env.PRIME_REGISTRY }}
+        prime-username: ${{ env.PRIME_REGISTRY_USERNAME }}
+        prime-password: ${{ env.PRIME_REGISTRY_PASSWORD }}

--- a/.github/workflows/image-push.yml
+++ b/.github/workflows/image-push.yml
@@ -16,17 +16,6 @@ jobs:
     - name: Check out code
       uses: actions/checkout@v4
 
-    - name: Set the TAG value
-      id: get-TAG
-      run: |
-        echo "$(make -s log | grep TAG)" >> "$GITHUB_ENV"
-
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@v3
-
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
-
     - name: "Read secrets"
       uses: rancher-eio/read-vault-secrets@main
       with:
@@ -34,19 +23,20 @@ jobs:
           secret/data/github/repo/${{ github.repository }}/dockerhub/${{ github.repository_owner }}/credentials username | DOCKER_USERNAME ;
           secret/data/github/repo/${{ github.repository }}/dockerhub/${{ github.repository_owner }}/credentials password | DOCKER_PASSWORD
 
-    - name: Login to Container Registry
-      uses: docker/login-action@v3
+    - name: Build and push image
+      uses: rancher/ecm-distro-tools/actions/publish-image@master
       with:
-        username: ${{ env.DOCKER_USERNAME }}
-        password: ${{ env.DOCKER_PASSWORD }}
-
-    - name: Build container image
-      uses: docker/build-push-action@v6
-      with:
-        context: .
-        push: true
-        tags: rancher/hardened-addon-resizer:${{ github.event.release.tag_name }}
-        file: Dockerfile
+        image: "hardened-addon-resizer"
+        tag: ${{ github.event.release.tag_name }}
         platforms: linux/amd64, linux/arm64
-        build-args: |
-          TAG=${{ env.TAG }}
+
+        public-registry: docker.io
+        public-repo: rancher
+        public-username: ${{ env.DOCKER_USERNAME }}
+        public-password: ${{ env.DOCKER_PASSWORD }}
+
+        push-to-prime: false
+        prime-registry: ${{ env.PRIME_REGISTRY }}
+        prime-repo: rancher
+        prime-username: ${{ env.PRIME_REGISTRY_USERNAME }}
+        prime-password: ${{ env.PRIME_REGISTRY_PASSWORD }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN set -x && \
     make
 
 FROM base as builder
-ARG ARCH
+ARG TARGETARCH
 ARG SRC=github.com/kubernetes/autoscaler
 ARG PKG=github.com/kubernetes/autoscaler
 RUN git clone https://${SRC}.git $GOPATH/src/${PKG}
@@ -19,10 +19,10 @@ WORKDIR $GOPATH/src/${PKG}/addon-resizer
 RUN git branch -a
 RUN git checkout addon-resizer-${TAG} -b ${TAG}
 RUN ls
-RUN GOARCH=${ARCH} GO_LDFLAGS="-linkmode=external -X ${PKG}/pkg/version.VERSION=${TAG}" \
+RUN GOARCH=${TARGETARCH} GO_LDFLAGS="-linkmode=external -X ${PKG}/pkg/version.VERSION=${TAG}" \
     go-build-static.sh -gcflags=-trimpath=${GOPATH}/src -o pod_nanny nanny/main/pod_nanny.go
 RUN go-assert-static.sh pod_nanny
-RUN if [ "${ARCH}" = "amd64" ]; then \
+RUN if [ "${TARGETARCH}" = "amd64" ]; then \
         go-assert-boring.sh pod_nanny; \
     fi
 RUN install -s pod_nanny /usr/local/bin

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,16 @@
 SEVERITIES = HIGH,CRITICAL
 
+UNAME_M = $(shell uname -m)
+ifndef TARGET_PLATFORMS
+	ifeq ($(UNAME_M), x86_64)
+		TARGET_PLATFORMS:=linux/amd64
+	else ifeq ($(UNAME_M), aarch64)
+		TARGET_PLATFORMS:=linux/arm64
+	else 
+		TARGET_PLATFORMS:=linux/$(UNAME_M)
+	endif
+endif
+
 BUILD_META=-build$(shell date +%Y%m%d)
 PKG ?= github.com/kubernetes/autoscaler
 SRC ?= github.com/kubernetes/autoscaler
@@ -12,25 +23,37 @@ endif
 
 REPO ?= rancher
 IMAGE = $(REPO)/hardened-addon-resizer:$(TAG)
-TARGET_PLATFORMS ?= linux/amd64,linux/arm64
+BUILD_OPTS = \
+	--platform=$(TARGET_PLATFORMS) \
+	--build-arg PKG=$(PKG) \
+	--build-arg SRC=$(SRC) \
+	--build-arg TAG=$(TAG:$(BUILD_META)=) \
+	--tag "$(IMAGE)"
+
+.PHONY: image-build
+image-build:
+	docker buildx build \
+		$(BUILD_OPTS) \
+		--load \
+		.
 
 .PHONY: push-image
 push-image:
 	docker buildx build \
+		$(BUILD_OPTS) \
 		--sbom=true \
 		--attest type=provenance,mode=max \
-		--platform=$(TARGET_PLATFORMS) \
-		--build-arg PKG=$(PKG) \
-		--build-arg SRC=$(SRC) \
-		--build-arg TAG=$(TAG:$(BUILD_META)=) \
-		--tag "$(IMAGE)" \
 		--push \
 		.
 
 .PHONY: log
 log:
-	@echo "IMAGE=$(IMAGE)"
 	@echo "TAG=$(TAG:$(BUILD_META)=)"
+	@echo "REPO=$(REPO)"
+	@echo "IMAGE=$(IMAGE)"
 	@echo "PKG=$(PKG)"
 	@echo "SRC=$(SRC)"
 	@echo "BUILD_META=$(BUILD_META)"
+	@echo "UNAME_M=$(UNAME_M)"
+	@echo "TARGET_PLATFORMS=$(TARGET_PLATFORMS)"
+

--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,6 @@
 SEVERITIES = HIGH,CRITICAL
 
-UNAME_M = $(shell uname -m)
-ARCH=
-ifeq ($(UNAME_M), x86_64)
-	ARCH=amd64
-else ifeq ($(UNAME_M), aarch64)
-	ARCH=arm64
-else 
-	ARCH=$(UNAME_M)
-endif
-
 BUILD_META=-build$(shell date +%Y%m%d)
-ORG ?= rancher
 PKG ?= github.com/kubernetes/autoscaler
 SRC ?= github.com/kubernetes/autoscaler
 TAG ?= ${GITHUB_ACTION_TAG}
@@ -21,26 +10,27 @@ ifeq ($(TAG),)
 TAG := 1.8.20$(BUILD_META)
 endif
 
-.PHONY: image-build
-image-build:
+REPO ?= rancher
+IMAGE = $(REPO)/hardened-addon-resizer:$(TAG)
+TARGET_PLATFORMS ?= linux/amd64,linux/arm64
+
+.PHONY: push-image
+push-image:
 	docker buildx build \
-		--platform=$(ARCH) \
-		--build-arg ARCH=$(ARCH) \
+		--sbom=true \
+		--attest type=provenance,mode=max \
+		--platform=$(TARGET_PLATFORMS) \
 		--build-arg PKG=$(PKG) \
 		--build-arg SRC=$(SRC) \
 		--build-arg TAG=$(TAG:$(BUILD_META)=) \
-		--tag $(ORG)/hardened-addon-resizer:$(TAG) \
-		--tag $(ORG)/hardened-addon-resizer:$(TAG)-$(ARCH) \
-		--load \
+		--tag "$(IMAGE)" \
+		--push \
 		.
 
 .PHONY: log
 log:
-	@echo "ARCH=$(ARCH)"
+	@echo "IMAGE=$(IMAGE)"
 	@echo "TAG=$(TAG:$(BUILD_META)=)"
-	@echo "ORG=$(ORG)"
 	@echo "PKG=$(PKG)"
 	@echo "SRC=$(SRC)"
 	@echo "BUILD_META=$(BUILD_META)"
-	@echo "UNAME_M=$(UNAME_M)"
-


### PR DESCRIPTION
- use rancher/ecm-distro-tools/actions/publish-image to build and push images
- adds make target push-image
- adds sbom to docker build arguments
- signs images that are pushed to the prime registry