### PR TITLE
Add IID_FILE_FLAG to push-image target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,7 @@ image-build:
 push-image:
 	docker buildx build \
 		$(BUILD_OPTS) \
+		$(IID_FILE_FLAG) \
 		--sbom=true \
 		--attest type=provenance,mode=max \
 		--push \


### PR DESCRIPTION
Fixing the use of the publish-image action. Cosign expects the image tag to be in a predetermined file, and it's simplest to respect the IID_FILE_FLAG variable in the push-image target.