### PR TITLE
Add manifiest to bump to the latest upstream version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,5 @@
-#ARG BCI_IMAGE=registry.suse.com/bci/bci-busybox
 ARG GO_IMAGE=rancher/hardened-build-base:v1.22.7b1
 
-#FROM ${BCI_IMAGE} as bci
 FROM ${GO_IMAGE} as base
 
 RUN set -x && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,13 @@
 ARG GO_IMAGE=rancher/hardened-build-base:v1.22.7b1
 
-FROM ${GO_IMAGE} as base
+FROM ${GO_IMAGE} AS base
 
 RUN set -x && \
     apk --no-cache add \
     git \
     make
 
-FROM base as builder
+FROM base AS builder
 ARG TARGETARCH
 ARG SRC=github.com/kubernetes/autoscaler
 ARG PKG=github.com/kubernetes/autoscaler

--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,10 @@ push-image:
 		--push \
 		.
 
+.PHONY: image-scan
+image-scan:
+	trivy --severity $(SEVERITIES) --no-progress --ignore-unfixed image $(IMAGE)
+
 .PHONY: log
 log:
 	@echo "TAG=$(TAG:$(BUILD_META)=)"

--- a/updatecli/updatecli.d/update-upstream.yaml
+++ b/updatecli/updatecli.d/update-upstream.yaml
@@ -1,0 +1,66 @@
+---
+name: "Update upstream version"
+
+sources:
+ upstream:
+   name: Get upstream version
+   kind: githubrelease
+   spec:
+     owner: kubernetes
+     repository: autoscaler
+     token: '{{ requiredEnv .github.token }}'
+     typefilter:
+       release: true
+       draft: false
+       prerelease: false
+     versionfilter:
+       kind: regex
+       pattern: "addon-resizer-1.(\\d*).(\\d*)$"
+   transformers:
+      - trimprefix: "addon-resizer-"
+
+targets:
+  dockerfile:
+    name: 'Bump Dockerfile to upstream version {{ source "upstream" }}'
+    kind: dockerfile
+    scmid: default
+    sourceid: upstream
+    spec:
+      file: "Dockerfile"
+      instruction:
+        keyword: "ARG"
+        matcher: "TAG"
+
+  makefile:
+    name: 'Bump Makefile to upstream version {{ source "upstream" }}'
+    kind: file
+    scmid: default
+    disablesourceinput: true
+    spec:
+      file: Makefile
+      matchpattern: '(?m)^TAG \:\= (.*)'
+      replacepattern: 'TAG := {{ source "upstream" }}$$(BUILD_META)'
+
+scms:
+  default:
+    kind: github
+    spec:
+      token: '{{ requiredEnv .github.token }}'
+      username: '{{ requiredEnv .github.username }}'
+      user: '{{ .github.user }}'
+      email: '{{ .github.email }}'
+      owner: '{{ .github.owner }}'
+      repository: '{{ .github.repository }}'
+      branch: '{{ .github.branch }}'
+
+actions:
+    default:
+        title: 'Bump to upstream version {{ source "upstream" }}'
+        kind: github/pullrequest
+        spec:
+            automerge: false
+            labels:
+                - chore
+                - skip-changelog
+                - status/auto-created
+        scmid: default

--- a/updatecli/values.yaml
+++ b/updatecli/values.yaml
@@ -4,5 +4,5 @@ github:
   username: "UPDATECLI_GITHUB_ACTOR"
   token: "UPDATECLI_GITHUB_TOKEN"
   repository: "image-build-addon-resizer"
-  branch: "master"
+  branch: "main"
   owner: "rancher"


### PR DESCRIPTION
* Fix broken `UpdateCli` github action
* Add manifiest to bump Makefile/Dockerfile to the latest upstream release
* Add `image-scan` Makefile target

Works:
* https://github.com/mgfritch/image-build-addon-resizer/pull/1
* https://github.com/mgfritch/image-build-addon-resizer/pull/2