### PR TITLE
Fix broken github/updatecli actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,7 @@
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
 
 permissions:

--- a/.github/workflows/updatecli.yml
+++ b/.github/workflows/updatecli.yml
@@ -15,7 +15,7 @@ permissions:
 jobs:
   updatecli:
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/master'
+    if: github.ref == 'refs/heads/main'
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/updatecli/updatecli.d/updatecli.yml
+++ b/updatecli/updatecli.d/updatecli.yml
@@ -28,7 +28,7 @@ scms:
       token: '{{ requiredEnv .github.token }}'
       owner: golang
       repository: go
-      branch: master
+      branch: main
 
 sources:
   # validate gittag parsing external public repos


### PR DESCRIPTION
Updatecli actions have been skipped due to an incorrect branch name configuration:

```
ERROR: something went wrong in "target#dockerfile" : something went wrong in target "dockerfile" : "reference not found"

Pipeline "Update build base version" failed
Skipping due to:
something went wrong during target execution
```

Fixup: afd5b193aff1d7b3f71de640711863f5b767ace1