### PR TITLE
Bump hardened-build-base to v1.24.1b1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG GO_IMAGE=rancher/hardened-build-base:v1.22.12b1
+ARG GO_IMAGE=rancher/hardened-build-base:v1.24.1b1
 
 FROM ${GO_IMAGE} AS base
 


### PR DESCRIPTION
Bump hardened-build-base to the `toolchain` version defined in the upstream [go.mod](https://raw.githubusercontent.com/kubernetes/autoscaler/addon-resizer-release-1.8/addon-resizer/go.mod)

Resolves [build failure](https://github.com/rancher/image-build-addon-resizer/actions/runs/13907471328/job/38951396067?pr=32):
```
0.147 go: k8s.io/api in vendor/modules.txt requires go >= 1.23.0 (running go 1.22.12; GOTOOLCHAIN=local)
```